### PR TITLE
removing createJSModules for RN >= 47.1

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiPackage.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiPackage.java
@@ -18,11 +18,6 @@ public class AndroidWifiPackage implements ReactPackage {
     return modules;
   }
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Arrays.<ViewManager>asList();
   }


### PR DESCRIPTION
Starting from RN 47 the Superclass ReactPackage does not have a function named createJSModules hence building with this package throws the error: 
```error: method does not override or implement a method from a supertype``` 
this is a quick fix