### PR TITLE
Remove @override annotation

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiPackage.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiPackage.java
@@ -1,4 +1,5 @@
 package com.devstepbcn.wifi;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,12 +18,14 @@ public class AndroidWifiPackage implements ReactPackage {
     modules.add(new AndroidWifiModule(reactContext));
     return modules;
   }
-  @Override
+
+  // This method is kept for RN < 0.47 compatibility
   public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
+    return Collections.emptyList();
   }
+
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-      return Arrays.<ViewManager>asList();
+    return Arrays.<ViewManager>asList();
   }
 }


### PR DESCRIPTION
In React Native >= 0.47 this method no longer exists, so can't be
overridden and this annotation breaks the build. However, we still
need to keep the method, so that build project works for React
Native < 0.47.

Later, when the support for 0.46.* is dropped, we can remove this
method entirely.