### PR TITLE
Added getFrequency() to grab frequency for current wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ var wifi = require('react-native-android-wifi')
 
 Wifi connectivity status:
 ```javascript
-wifi.isEnabled((isEnabled)=>{
-  if (isEnabled){
+wifi.isEnabled((isEnabled) => {
+  if (isEnabled) {
     console.log("wifi service enabled");
-  }else{
+  } else {
     console.log("wifi service is disabled");
   }
 });
@@ -49,7 +49,7 @@ Sign device into a specific network:
 wifi.findAndConnect(ssid, password, (found) => {
   if (found) {
     console.log("wifi is in range");
-  }else{
+  } else {
     console.log("wifi is not in range");
   }
 });
@@ -102,7 +102,7 @@ connectionStatus returns true or false depending on whether device is connected 
 wifi.connectionStatus((isConnected) => {
   if (isConnected) {
       console.log("is connected");
-    }else{
+    } else {
       console.log("is not connected");
   }
 });
@@ -111,15 +111,22 @@ wifi.connectionStatus((isConnected) => {
 Get connected wifi signal strength
 ```javascript
 //level is the detected signal level in dBm, also known as the RSSI. (Remember its a negative value)
-wifi.getCurrentSignalStrength((level)=>{
+wifi.getCurrentSignalStrength((level) => {
   console.log(level);
 });
+```
+
+Get connected wifi frequency
+```javascript
+wifi.getFrequency((frequency) => {
+  console.log(frequency);
+})
 ```
 
 Get current IP
 ```javascript
 //get the current network connection IP
-wifi.getIP((ip)=>{
+wifi.getIP((ip) => {
   console.log(ip);
 });
 ```

--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -244,11 +244,20 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 		int linkSpeed = wifi.getConnectionInfo().getRssi();
 		callback.invoke(linkSpeed);
 	}
+
+	//This method will return current wifi frequency
+	@ReactMethod
+	public void getFrequency(final Callback callback) {
+		WifiInfo info = wifi.getConnectionInfo();
+		int frequency = info.getFrequency();
+		callback.invoke(frequency);
+	}
+
 	//This method will return current IP
 	@ReactMethod
 	public void getIP(final Callback callback) {
 		WifiInfo info = wifi.getConnectionInfo();
-		String stringip=longToIP(info.getIpAddress());
+		String stringip = longToIP(info.getIpAddress());
 		callback.invoke(stringip);
 	}
 


### PR DESCRIPTION
Using [WifiInfo.getFrequency()](https://developer.android.com/reference/android/net/wifi/WifiInfo.html#getFrequency()) to provide a prop for getting current wifi frequency.