### PR TITLE
Fix Wifi Leak

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -46,7 +46,7 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 	//Constructor
 	public AndroidWifiModule(ReactApplicationContext reactContext) {
 		super(reactContext);
-		wifi = (WifiManager)reactContext.getSystemService(Context.WIFI_SERVICE);
+		wifi = (WifiManager)reactContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
 		context = (ReactApplicationContext) getReactApplicationContext();
 	}
 


### PR DESCRIPTION
Fixes wifi leak lint error on build.

> The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing to .getApplicationContext() [WifiManagerLeak]