### PR TITLE
Updated README with Android 8.1 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ wifi.disconnect();
 ```
 
 Get current SSID
+
+Starting with Android 8.1 (API 27), apps must be granted the ACCESS_COARSE_LOCATION (or ACCESS_FINE_LOCATION) permission in order to obtain results from getSSID().
 ```javascript
 wifi.getSSID((ssid) => {
   console.log(ssid);
@@ -88,6 +90,8 @@ wifi.getSSID((ssid) => {
 ```
 
 Get current BSSID
+
+Starting with Android 8.1 (API 27), apps must be granted the ACCESS_COARSE_LOCATION (or ACCESS_FINE_LOCATION) permission in order to obtain results from getBSSID().
 ```javascript
 wifi.getBSSID((bssid) => {
   console.log(bssid);


### PR DESCRIPTION
Updated README to indicate that `getSSID()` and `getBSSID` require additional permissions starting in Android 8.1.

reference: https://github.com/aosp-mirror/platform_frameworks_base/commit/e42dd31b3f656f33be99fd37f26e07557d163b54#diff-87dc47bf75c6bbb0d746d9671c2aedf6