### PR TITLE
Handle null return values from WifiManager.getConfiguredNetworks().

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -253,6 +253,10 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 		}
 
 		List<WifiConfiguration> mWifiConfigList = wifi.getConfiguredNetworks();
+		if (mWifiConfigList == null) {
+		    return false;
+        }
+
 		int updateNetwork = -1;
 
 		// Use the existing network config if exists
@@ -316,6 +320,11 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 	@ReactMethod
 	public void connectToHiddenNetwork(String ssid, String password, Callback networkAdded) {
 		List<WifiConfiguration> list = wifi.getConfiguredNetworks();
+		if (list == null) {
+			networkAdded.invoke(false);
+		    return;
+        }
+
 		int updateNetwork = -1;
 
 		// check if network config exists and it's hidden
@@ -419,6 +428,10 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 	@ReactMethod
 	public void isRemoveWifiNetwork(String ssid, final Callback callback) {
 	    List<WifiConfiguration> mWifiConfigList = wifi.getConfiguredNetworks();
+        if (mWifiConfigList == null) {
+            return;
+        }
+
 	    for (WifiConfiguration wifiConfig : mWifiConfigList) {
 			String comparableSSID = ('"' + ssid + '"'); //Add quotes because wifiConfig.SSID has them
 			if(wifiConfig.SSID.equals(comparableSSID)) {
@@ -464,6 +477,10 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 
 	private WifiConfiguration IsExist(String SSID) {
 		List<WifiConfiguration> existingConfigs = wifi.getConfiguredNetworks();
+		if (existingConfigs == null) {
+			return null;
+		}
+
 		for (WifiConfiguration existingConfig : existingConfigs) {
 			if (existingConfig.SSID.equals("\"" + SSID + "\"")) {
 				return existingConfig;


### PR DESCRIPTION
Handle null return values from WifiManager.getConfiguredNetworks(). 

Before the fix, here is a crash dump from Google Play, when using react-native-android-wifi 0.0.34.

--

LGE LG G3 (g3), Android 5.0

java.lang.NullPointerException: 
  at com.devstepbcn.wifi.AndroidWifiModule.connectTo (AndroidWifiModule.java:259)
  at com.devstepbcn.wifi.AndroidWifiModule.findAndConnect (AndroidWifiModule.java:182)
  at java.lang.reflect.Method.invoke (Native Method)
  at java.lang.reflect.Method.invoke (Method.java:372)
  at com.facebook.react.bridge.JavaMethodWrapper.invoke (JavaMethodWrapper.java:372)
  at com.facebook.react.bridge.JavaModuleWrapper.invoke (JavaModuleWrapper.java:160)
  at com.facebook.react.bridge.queue.NativeRunnable.run (Native Method)
  at android.os.Handler.handleCallback (Handler.java:739)
  at android.os.Handler.dispatchMessage (Handler.java:95)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage (MessageQueueThreadHandler.java:29)
  at android.os.Looper.loop (Looper.java:135)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run (MessageQueueThreadImpl.java:192)
  at java.lang.Thread.run (Thread.java:818)