### PR TITLE
Don't request special permissions on SDK 24+ when calling forceWifiUsage

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -106,7 +106,10 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
         if (useWifi) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    canWriteFlag = true;
+                    // Only need ACTION_MANAGE_WRITE_SETTINGS on 6.0.0, regular permissions suffice on later versions
+                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     canWriteFlag = Settings.System.canWrite(reactContext);
 
                     if (!canWriteFlag) {
@@ -520,4 +523,3 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 		}
 	}
 }
-


### PR DESCRIPTION
The advanced permission Modify System Settings is only needed to force wifi usage on Android version 6.0.0. On SDK 24+, normal permissions that we already use in this app that don't require user approval are sufficient for forcing wifi usage. Taking a user to an advanced permission page and forcing an unneeded permission to perform something already allowed is a bad user experience. For more information, please see:

https://stackoverflow.com/questions/32185628/connectivitymanager-requestnetwork-in-android-6-0#answer-33509180
"...no longer needed in Android 6.0.1. WRITE_SETTING and CHANGE_NETWORK_STATE are no longer the same thing"
"This was an Android 6.0 bug. It's fixed in Android 6.0.1, requestNetwork() can be called if you request CHANGE_NETWORK_STATE in the manifest. No need to call requestPermissions(), it's a normal permission."
"UPDATE: as of Android 6.0.1, CHANGE_NETWORK_STATE is auto granted when requested in your manifest file. The above WRITE_SETTINGS checks are only required for 6.0"

Note: We could also specify Build.VERSION.RELEASE to get the bug fix version number and only request this permission in 6.0.0, as 6.0.1 should follow 7+ behavior, but I only have Android devices with Android 7-9 to test and figured a simpler fix now would solve the problem for most users.