### PR TITLE
Fix forceWifi for Android 6.0.1 devices

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -109,9 +109,12 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     canWriteFlag = true;
                     // Only need ACTION_MANAGE_WRITE_SETTINGS on 6.0.0, regular permissions suffice on later versions
+                } else if (Build.VERSION.RELEASE.toString().equals("6.0.1")) {
+					canWriteFlag = true;
+					// Don't need ACTION_MANAGE_WRITE_SETTINGS on 6.0.1, if we can positively identify it treat like 7+
                 } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+					// On M 6.0.0 (N+ or higher and 6.0.1 hit above), we need ACTION_MANAGE_WRITE_SETTINGS to forceWifi.
                     canWriteFlag = Settings.System.canWrite(reactContext);
-
                     if (!canWriteFlag) {
                         Intent intent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS);
                         intent.setData(Uri.parse("package:" + reactContext.getPackageName()));

--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -110,10 +110,10 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
                     canWriteFlag = true;
                     // Only need ACTION_MANAGE_WRITE_SETTINGS on 6.0.0, regular permissions suffice on later versions
                 } else if (Build.VERSION.RELEASE.toString().equals("6.0.1")) {
-					canWriteFlag = true;
-					// Don't need ACTION_MANAGE_WRITE_SETTINGS on 6.0.1, if we can positively identify it treat like 7+
+                    canWriteFlag = true;
+                    // Don't need ACTION_MANAGE_WRITE_SETTINGS on 6.0.1, if we can positively identify it treat like 7+
                 } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-					// On M 6.0.0 (N+ or higher and 6.0.1 hit above), we need ACTION_MANAGE_WRITE_SETTINGS to forceWifi.
+                    // On M 6.0.0 (N+ or higher and 6.0.1 hit above), we need ACTION_MANAGE_WRITE_SETTINGS to forceWifi.
                     canWriteFlag = Settings.System.canWrite(reactContext);
                     if (!canWriteFlag) {
                         Intent intent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS);


### PR DESCRIPTION
ACTION_MANAGE_WRITE_SETTINGS(AMWS) is only needed to forceWifi on Android 6.0.0, this was fixed in Android 6.0.1 and later. We are already not requesting the AMWS permission on Android 7+. I now have a Samsung device on Android 6.0.1 so I was able to verify that the following fix works on 6.0.1, but will leave 6.0.0 functionality unchanged. Android 7+ functionality is also unaffected by this change, and if we are unable to positively identify if an Android 6 device is on 6.0.1 or not we will default to requesting AMWS.