### PR TITLE
Use application context to get system service

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -46,7 +46,7 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 	public AndroidWifiModule(ReactApplicationContext reactContext) {
 		super(reactContext);
 
-		wifi = (WifiManager)reactContext.getSystemService(Context.WIFI_SERVICE);
+		wifi = (WifiManager)reactContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
 		this.reactContext = reactContext;
 	}
 


### PR DESCRIPTION
This fixes the exception when building the application:

```
react-native-android-wifi/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java:49: Error: The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing reactContext to reactContext.getApplicationContext()  [WifiManagerLeak]
  wifi = (WifiManager)reactContext.getSystemService(Context.WIFI_SERVICE);
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "WifiManagerLeak":
   On versions prior to Android N (24), initializing the WifiManager via
   Context#getSystemService can cause a memory leak if the context is not the
   application context. Change context.getSystemService(...) to
   context.getApplicationContext().getSystemService(...).
```