### PR TITLE
Bugfix: improve branching logic and permissions comments

### DIFF
--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -105,21 +105,16 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
 		
         if (useWifi) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N || Build.VERSION.RELEASE.toString().equals("6.0.1")) {
+                    // In versions >= 6.0.1, we no longer need to request permission to write to settings.
                     canWriteFlag = true;
-                    // Only need ACTION_MANAGE_WRITE_SETTINGS on 6.0.0, regular permissions suffice on later versions
-                } else if (Build.VERSION.RELEASE.toString().equals("6.0.1")) {
-                    canWriteFlag = true;
-                    // Don't need ACTION_MANAGE_WRITE_SETTINGS on 6.0.1, if we can positively identify it treat like 7+
                 } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    // On M 6.0.0 (N+ or higher and 6.0.1 hit above), we need ACTION_MANAGE_WRITE_SETTINGS to forceWifi.
+                    // In version 6.0.0, we need to request permission to write to settings in order to forceWifi.
                     canWriteFlag = Settings.System.canWrite(reactContext);
                     if (!canWriteFlag) {
                         Intent intent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS);
                         intent.setData(Uri.parse("package:" + reactContext.getPackageName()));
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-
                         reactContext.startActivity(intent);
                     }
                 }

--- a/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
+++ b/android/src/main/java/com/devstepbcn/wifi/AndroidWifiModule.java
@@ -131,17 +131,19 @@ public class AndroidWifiModule extends ReactContextBaseJavaModule {
                     manager.requestNetwork(builder.build(), new ConnectivityManager.NetworkCallback() {
                         @Override
                         public void onAvailable(Network network) {
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                                manager.bindProcessToNetwork(network);
-                            } else {
-                                //This method was deprecated in API level 23
-                                ConnectivityManager.setProcessDefaultNetwork(network);
-                            }
                             try {
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                                    manager.bindProcessToNetwork(network);
+                                } else {
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                                        //This method was deprecated in API level 23
+                                        ConnectivityManager.setProcessDefaultNetwork(network);
+                                    }
+                                }
+                                manager.unregisterNetworkCallback(this);
                             } catch (Exception e) {
                                 e.printStackTrace();
                             }
-                            manager.unregisterNetworkCallback(this);
                         }
                     });
                 }


### PR DESCRIPTION
This PR fixes a bug in the placement of code that was intended to be within a try/catch block. It also improves and simplifies the logic and comments around requesting permissions for specific Android versions. Basically, I ran into a bug that was hard to figure out because the code was difficult to understand. I later learned that newer versions of Android (6.0.1+) no longer need to request permission to write to settings, but this wasn't clear enough in the code.