### PR TITLE
add `react-native.config.js` for RN 0.60 compat

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      ios: {},
+      android: {
+        "packageInstance": "new AndroidWifiPackage()"
+      },
+    },
+  },
+}

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -8,3 +8,4 @@ module.exports = {
     },
   },
 }
+


### PR DESCRIPTION
`rnpm` is being deprecated in newer versions of the react-native cli. As a result, the previous `rnpm` configurations inside the `package.json` need to moved to a new `react-native.config.js` file to support RN 0.60. 

related https://github.com/devstepbcn/react-native-android-wifi/issues/97

More info https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide.