### PR TITLE
Add missing Rational, [buttonNeutral,buttonNegative,buttonPositive]

### DIFF
--- a/Examples/ExampleAPI25/App.js
+++ b/Examples/ExampleAPI25/App.js
@@ -49,7 +49,10 @@ export default class App extends Component<Props> {
         PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
         {
           'title': 'Wifi networks',
-          'message': 'We need your permission in order to find wifi networks'
+          'message': 'We need your permission in order to find wifi networks',
+          buttonNeutral: "Ask Me Later",
+          buttonNegative: "Cancel",
+          buttonPositive: "OK"
         }
       )
       if (granted === PermissionsAndroid.RESULTS.GRANTED) {


### PR DESCRIPTION
This PR resolve the missing Rational [buttonNeutral,buttonNegative,buttonPositive] .

> If rationale is provided, this function checks with the OS whether it is necessary to show a dialog explaining why the permission is needed.
> (https://developer.android.com/training/permissions/requesting.html#explain) and then shows the system permission dialog.

Reference:https://reactnative.dev/docs/permissionsandroid